### PR TITLE
Add `method` validity assertions

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,25 @@
+import { assert } from '@ember/debug';
+
+const VALID_METHODS = [
+  'GET',
+  'HEAD',
+  'POST',
+  'PUT',
+  'DELETE',
+  'OPTIONS',
+  'PATCH',
+];
+
 export async function apiAction(record, { method, path, data }) {
+  assert(`Missing \`method\` option`, method);
+  assert(
+    [
+      `Invalid \`method\` option: ${method}`,
+      `Valid options: ${VALID_METHODS.join(', ')}`,
+    ].join('\n'),
+    VALID_METHODS.includes(method)
+  );
+
   let modelClass = record.constructor;
   let modelName = modelClass.modelName;
   let adapter = record.store.adapterFor(modelName);


### PR DESCRIPTION
This will ensure that all calls have an explicit `method` option set.