### PR TITLE
Add `requestType` option

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -10,7 +10,10 @@ const VALID_METHODS = [
   'PATCH',
 ];
 
-export async function apiAction(record, { method, path, data }) {
+export async function apiAction(
+  record,
+  { requestType = 'updateRecord', method, path, data }
+) {
   assert(`Missing \`method\` option`, method);
   assert(
     [
@@ -24,7 +27,6 @@ export async function apiAction(record, { method, path, data }) {
   let modelName = modelClass.modelName;
   let adapter = record.store.adapterFor(modelName);
 
-  let requestType = 'updateRecord';
   let baseUrl = adapter.buildURL(modelName, record.id, null, requestType);
   let url = path ? `${baseUrl}/${path}` : baseUrl;
 

--- a/tests/unit/custom-actions-test.js
+++ b/tests/unit/custom-actions-test.js
@@ -32,6 +32,22 @@ module('customAction()', function (hooks) {
     assert.deepEqual(response, { success: true });
   });
 
+  test('requestType option changes the base URL', async function (assert) {
+    let { worker, rest, user } = await prepare(this);
+
+    worker.use(
+      rest.post('/users', (req, res, ctx) => {
+        return res(ctx.json({ requestType: 'works' }));
+      })
+    );
+
+    let response = await apiAction(user, {
+      method: 'POST',
+      requestType: 'createRecord',
+    });
+    assert.deepEqual(response, { requestType: 'works' });
+  });
+
   test('it fails as expected', async function (assert) {
     let { worker, rest, user } = await prepare(this);
 


### PR DESCRIPTION
This can be useful in certain cases, e.g. when we need to perform a pre-creation check on a model.