### PR TITLE
Pass record snapshots to `buildURL()` method

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -27,7 +27,9 @@ export async function apiAction(
   let modelName = modelClass.modelName;
   let adapter = record.store.adapterFor(modelName);
 
-  let baseUrl = adapter.buildURL(modelName, record.id, null, requestType);
+  let snapshot = record._createSnapshot();
+
+  let baseUrl = adapter.buildURL(modelName, record.id, snapshot, requestType);
   let url = path ? `${baseUrl}/${path}` : baseUrl;
 
   return await adapter.ajax(url, method, { data });


### PR DESCRIPTION
This is not needed for the default implementations of the `buildURL()` method, but some custom adapters might be relying on this parameter to be available.