### PR TITLE
ember-try: Replace ember-source with ember-data scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,10 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
-          - ember-lts-4.4
-          - ember-release
-          - ember-beta
-          - ember-canary
-          - ember-classic
+          - ember-data-3.28
+          - ember-data-4.4
+          - ember-data-4.7
+          - ember-data-4.8
           - embroider-safe
           - embroider-optimized
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
@@ -8,60 +7,34 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
+        name: 'ember-data-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.28.0',
+            'ember-data': '3.28.12',
           },
         },
       },
       {
-        name: 'ember-lts-4.4',
+        name: 'ember-data-4.4',
         npm: {
           devDependencies: {
-            'ember-source': '~4.4.0',
+            'ember-data': '4.4.1',
           },
         },
       },
       {
-        name: 'ember-release',
+        name: 'ember-data-4.7',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release'),
+            'ember-data': '4.7.3',
           },
         },
       },
       {
-        name: 'ember-beta',
+        name: 'ember-data-4.8',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('beta'),
-          },
-        },
-      },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
-      {
-        name: 'ember-classic',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'application-template-wrapper': true,
-            'default-async-observers': false,
-            'template-only-glimmer-components': false,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-          ember: {
-            edition: 'classic',
+            'ember-data': '4.8.2',
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "ember-qunit": "6.0.0",
     "ember-resolver": "8.0.3",
     "ember-source": "4.8.2",
-    "ember-source-channel-url": "3.0.0",
     "ember-template-lint": "4.17.0",
     "ember-try": "2.0.0",
     "eslint": "7.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,6 @@ specifiers:
   ember-qunit: 6.0.0
   ember-resolver: 8.0.3
   ember-source: 4.8.2
-  ember-source-channel-url: 3.0.0
   ember-template-lint: 4.17.0
   ember-try: 2.0.0
   eslint: 7.32.0
@@ -68,7 +67,6 @@ devDependencies:
   ember-qunit: 6.0.0_qlun7vkcguccocg2zpe7gp5kwa
   ember-resolver: 8.0.3
   ember-source: 4.8.2_gsocywzcpltb62s22lnmo6ims4
-  ember-source-channel-url: 3.0.0
   ember-template-lint: 4.17.0_ember-cli-htmlbars@6.1.1
   ember-try: 2.0.0
   eslint: 7.32.0


### PR DESCRIPTION
There is no need to test with multiple Ember versions, but testing with multiple Ember Data versions would be quite beneficial.