### PR TITLE
Add support for `adapterOptions`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -12,7 +12,7 @@ const VALID_METHODS = [
 
 export async function apiAction(
   record,
-  { requestType = 'updateRecord', method, path, data }
+  { requestType = 'updateRecord', method, path, data, adapterOptions }
 ) {
   assert(`Missing \`method\` option`, method);
   assert(
@@ -28,6 +28,10 @@ export async function apiAction(
   let adapter = record.store.adapterFor(modelName);
 
   let snapshot = record._createSnapshot();
+
+  if (adapterOptions) {
+    snapshot.adapterOptions = adapterOptions;
+  }
 
   let baseUrl = adapter.buildURL(modelName, record.id, snapshot, requestType);
   let url = path ? `${baseUrl}/${path}` : baseUrl;


### PR DESCRIPTION
Allows to pass adapterOptions to the `buildUrl` hook. 

We currently have an errorHandlers abstraction that we're in the process of migrating. It looks roughly something like this:

```javascript
export default class ApplicationAdapter extends ActiveModelAdapter {
//...
buildURL(modelName, id, snapshot, requestType, query) {
    let url = new URL(super.buildURL(modelName, id, snapshot, requestType, query));
    if (snapshot?.adapterOptions?.globalErrors) {
      url.searchParams.append('_ge', 't');
    }
    return url.toString();
  }

  useGlobalErrors(urlString) {
    let url = new URL(urlString);
    return url.searchParams.get('_ge') === 't';
  }

  handleResponse(status, headers, payload, requestData) {
    let result = super.handleResponse(status, headers, payload, requestData);

    if (result instanceof Error) {
      result.status = status;
      result.url = requestData.url;
      result.method = requestData.method;
      result.globalErrors = this.useGlobalErrors(requestData.url);
    }

    if (status >= 400 && status !== 404 && status !== 422) {
     // the errorsHandler will rely on  result.globalErrors
      this.networkManager.errorsHandler(result);
    }

    return result;
  }
```

For api actions we need to incrementally update all of them and have a way to tell the adapter that we want to rely on the `globalErrors`. Let me know if there's a better/easier way to do this :)