### PR TITLE
Allow apiAction to handle query params

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -58,7 +58,7 @@ export async function apiAction(
 export async function adapterAction(
   adapter,
   modelName,
-  { requestType = 'createRecord', method, path, data }
+  { requestType = 'createRecord', method, path = '', data }
 ) {
   assert(`Missing \`method\` option`, method);
   assert(
@@ -70,7 +70,22 @@ export async function adapterAction(
   );
 
   let baseUrl = adapter.buildURL(modelName, null, null, requestType);
-  let url = path ? `${baseUrl}/${path}` : baseUrl;
+  let url;
+  const [baseUrlNoQueries, baseQueries] = baseUrl.split('?');
+  const [pathNoQueries, pathQueries] = path.split('?');
+
+  if (baseUrlNoQueries.charAt(baseUrl.length - 1) === '/') {
+    url = `${baseUrlNoQueries}${pathNoQueries}`;
+  } else {
+    url = `${baseUrlNoQueries}/${pathNoQueries}`;
+  }
+
+  const baseSearchParams = new URLSearchParams(baseQueries);
+  const pathSearchParams = new URLSearchParams(pathQueries);
+  for (const [k, v] of pathSearchParams) {
+    baseSearchParams.set(k, v);
+  }
+  url = `${url}?${baseSearchParams.toString()}`;
 
   return await adapter.ajax(url, method, { data });
 }

--- a/tests/unit/adapter-actions-test.js
+++ b/tests/unit/adapter-actions-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { adapterAction } from '@mainmatter/ember-api-actions';
 import { ServerError } from '@ember-data/adapter/error';
+import RESTAdapter from '@ember-data/adapter/rest';
 
 module('adapterAction()', function (hooks) {
   setupTest(hooks);
@@ -47,5 +48,91 @@ module('adapterAction()', function (hooks) {
       }),
       ServerError
     );
+  });
+
+  module('when adapter buildURL returns with query params', function (hooks) {
+    hooks.beforeEach(function () {
+      class UserAdapter extends RESTAdapter {
+        buildURL(modelName, id, snapshot, requestType) {
+          let url = super.buildURL(modelName, id, snapshot, requestType);
+          let params = new URLSearchParams({ order: 'asc' });
+          return `${url}?${params.toString()}`;
+        }
+      }
+      this.owner.register('adapter:user', UserAdapter);
+    });
+
+    test('should handle query params', async function (assert) {
+      assert.expect(2);
+      let { worker, rest, adapter } = await prepare(this);
+
+      worker.use(
+        rest.post('/users?order=asc', (req, res, ctx) => {
+          assert.strictEqual(
+            req.url.searchParams.get('order'),
+            'asc',
+            'request made to the right URL'
+          );
+          return res(ctx.json({ adapterOptions: 'it works' }));
+        })
+      );
+
+      let response = await adapterAction(adapter, 'user', {
+        method: 'POST',
+        requestType: 'createRecord',
+      });
+      assert.deepEqual(response, { adapterOptions: 'it works' });
+    });
+
+    test('should handle query params and path params', async function (assert) {
+      assert.expect(3);
+      let { worker, rest, adapter } = await prepare(this);
+
+      worker.use(
+        rest.post('/users/like?order=asc', (req, res, ctx) => {
+          assert.strictEqual(
+            req.url.searchParams.get('order'),
+            'asc',
+            'request param order has the correct value'
+          );
+          assert.strictEqual(
+            req.url.searchParams.get('limit'),
+            '10',
+            'request param limit has the correct value'
+          );
+          return res(ctx.json({ adapterOptions: 'it works' }));
+        })
+      );
+
+      let response = await adapterAction(adapter, 'user', {
+        method: 'POST',
+        path: 'like?limit=10',
+      });
+      assert.deepEqual(response, { adapterOptions: 'it works' });
+    });
+
+    module('when adapter buildURL and path query params conflict', function () {
+      test('should choose to keep path query params', async function (assert) {
+        assert.expect(2);
+        let { worker, rest, adapter } = await prepare(this);
+
+        worker.use(
+          rest.post('/users/like?order=asc', (req, res, ctx) => {
+            assert.strictEqual(
+              req.url.searchParams.get('order'),
+              'desc',
+              'request param order has the correct value'
+            );
+            return res(ctx.json({ adapterOptions: 'it works' }));
+          })
+        );
+
+        let response = await adapterAction(adapter, 'user', {
+          method: 'POST',
+          path: 'like?order=desc',
+        });
+        assert.deepEqual(response, { adapterOptions: 'it works' });
+      });
+    });
   });
 });

--- a/tests/unit/custom-actions-test.js
+++ b/tests/unit/custom-actions-test.js
@@ -117,4 +117,90 @@ module('customAction()', function (hooks) {
     });
     assert.deepEqual(response, { adapterOptions: 'it works' });
   });
+
+  module('when adapter buildURL returns with query params', function (hooks) {
+    hooks.beforeEach(function () {
+      class UserAdapter extends RESTAdapter {
+        buildURL(modelName, id, snapshot, requestType) {
+          let url = super.buildURL(modelName, id, snapshot, requestType);
+          let params = new URLSearchParams({ order: 'asc' });
+          return `${url}?${params.toString()}`;
+        }
+      }
+      this.owner.register('adapter:user', UserAdapter);
+    });
+
+    test('should handle query params', async function (assert) {
+      assert.expect(2);
+      let { worker, rest, user } = await prepare(this);
+
+      worker.use(
+        rest.post('/users?order=asc', (req, res, ctx) => {
+          assert.strictEqual(
+            req.url.searchParams.get('order'),
+            'asc',
+            'request made to the right URL'
+          );
+          return res(ctx.json({ adapterOptions: 'it works' }));
+        })
+      );
+
+      let response = await apiAction(user, {
+        method: 'POST',
+        requestType: 'createRecord',
+      });
+      assert.deepEqual(response, { adapterOptions: 'it works' });
+    });
+
+    test('should handle query params and path params', async function (assert) {
+      assert.expect(3);
+      let { worker, rest, user } = await prepare(this);
+
+      worker.use(
+        rest.post('/users/42/like?order=asc', (req, res, ctx) => {
+          assert.strictEqual(
+            req.url.searchParams.get('order'),
+            'asc',
+            'request param order has the correct value'
+          );
+          assert.strictEqual(
+            req.url.searchParams.get('limit'),
+            '10',
+            'request param limit has the correct value'
+          );
+          return res(ctx.json({ adapterOptions: 'it works' }));
+        })
+      );
+
+      let response = await apiAction(user, {
+        method: 'POST',
+        path: 'like?limit=10',
+      });
+      assert.deepEqual(response, { adapterOptions: 'it works' });
+    });
+
+    module('when adapter buildURL and path query params conflict', function () {
+      test('should choose to keep path query params', async function (assert) {
+        assert.expect(2);
+        let { worker, rest, user } = await prepare(this);
+
+        worker.use(
+          rest.post('/users/42/like?order=asc', (req, res, ctx) => {
+            assert.strictEqual(
+              req.url.searchParams.get('order'),
+              'desc',
+              'request param order has the correct value'
+            );
+            return res(ctx.json({ adapterOptions: 'it works' }));
+          })
+        );
+
+        let response = await apiAction(user, {
+          method: 'POST',
+          path: 'like?order=desc',
+        });
+        assert.deepEqual(response, { adapterOptions: 'it works' });
+      });
+    });
+  });
 });


### PR DESCRIPTION
The current iteration of apiAction does not handle query params. 

According to the official JSONAPI doc 
(https://api.emberjs.com/ember-data/4.9/classes/JSONAPIAdapter/methods/buildURL?anchor=buildURL) the `buildURL` function accepts a `query` 
argument to build the URL with it.

This PR adds query params handling and makes sure it returns a valid url even if a `path` is passed to the adapter options.
