### PR TITLE
Allow `buildURL()` overrides to return query parameters

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -34,7 +34,7 @@ export async function apiAction(
   }
 
   let baseUrl = adapter.buildURL(modelName, record.id, snapshot, requestType);
-  let url = path ? `${baseUrl}/${path}` : baseUrl;
+  let url = addPath(baseUrl, path);
 
   return await adapter.ajax(url, method, { data });
 }
@@ -55,7 +55,11 @@ export async function adapterAction(
   );
 
   let baseUrl = adapter.buildURL(modelName, null, null, requestType);
-  let url = path ? `${baseUrl}/${path}` : baseUrl;
+  let url = addPath(baseUrl, path);
 
   return await adapter.ajax(url, method, { data });
+}
+
+function addPath(baseUrl, path) {
+  return path ? `${baseUrl}/${path}` : baseUrl
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -61,5 +61,18 @@ export async function adapterAction(
 }
 
 function addPath(baseUrl, path) {
-  return path ? `${baseUrl}/${path}` : baseUrl
+  if (!path) return baseUrl;
+
+  let url = new URL(baseUrl, location.href);
+
+  let [pathname, search] = path.split('?', 2);
+  url.pathname += `/${pathname}`;
+
+  if (search) {
+    new URLSearchParams(search).forEach((value, name) => {
+      url.searchParams.append(name, value);
+    });
+  }
+
+  return url.href;
 }

--- a/tests/unit/custom-actions-test.js
+++ b/tests/unit/custom-actions-test.js
@@ -117,4 +117,21 @@ module('customAction()', function (hooks) {
     });
     assert.deepEqual(response, { adapterOptions: 'it works' });
   });
+
+  test('query params via `path` work correctly', async function (assert) {
+    let { worker, rest, user } = await prepare(this);
+
+    worker.use(
+      rest.post('/users/42/foo', (req, res, ctx) => {
+        let query = req.url.searchParams.get('query');
+        return res(ctx.json({ query }));
+      })
+    );
+
+    let response = await apiAction(user, {
+      method: 'POST',
+      path: 'foo?query=param',
+    });
+    assert.deepEqual(response, { query: 'param' });
+  });
 });

--- a/tests/unit/custom-actions-test.js
+++ b/tests/unit/custom-actions-test.js
@@ -134,4 +134,34 @@ module('customAction()', function (hooks) {
     });
     assert.deepEqual(response, { query: 'param' });
   });
+
+  test('query params from buildURL() work correctly', async function (assert) {
+    class UserAdapter extends RESTAdapter {
+      buildURL(modelName, id, snapshot, requestType) {
+        if (requestType === 'updateRecord') {
+          return `/foo?q1=adapter&q2=adapter`;
+        } else {
+          return super.buildURL(...arguments);
+        }
+      }
+    }
+
+    this.owner.register('adapter:user', UserAdapter);
+
+    let { worker, rest, user } = await prepare(this);
+
+    worker.use(
+      rest.post('/foo/bar', (req, res, ctx) => {
+        let q1 = req.url.searchParams.getAll('q1');
+        let q2 = req.url.searchParams.getAll('q2');
+        return res(ctx.json({ q1, q2 }));
+      })
+    );
+
+    let response = await apiAction(user, {
+      method: 'POST',
+      path: 'bar?q1=path',
+    });
+    assert.deepEqual(response, { q1: ['adapter', 'path'], q2: ['adapter'] });
+  });
 });


### PR DESCRIPTION
Previously, we were naively appending strings to build the final request URL, but this broke down when the `buildURL()` implementation of the adapter returned a URL with query parameters.

This MR fixes the issue by using the `URL` and `URLSearchParams` classes to combine the `buildURL()` output with the passed in `path` option.

Since this is relying on `URL.href` the requested URL will now be an absolute URL in all cases. While this is unlikely to be an issue in practice we might want to consider this a breaking change.