### PR TITLE
Pass adapterOptions to buildURL for adapterAction

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -43,7 +43,7 @@ export async function apiAction(
 export async function adapterAction(
   adapter,
   modelName,
-  { requestType = 'createRecord', method, path, data }
+  { requestType = 'createRecord', method, path, data, adapterOptions }
 ) {
   assert(`Missing \`method\` option`, method);
   assert(
@@ -54,7 +54,12 @@ export async function adapterAction(
     VALID_METHODS.includes(method)
   );
 
-  let baseUrl = adapter.buildURL(modelName, null, null, requestType);
+  let baseUrl = adapter.buildURL(
+    modelName,
+    null,
+    { adapterOptions },
+    requestType
+  );
   let url = addPath(baseUrl, path);
 
   return await adapter.ajax(url, method, { data });


### PR DESCRIPTION
This allows `adapterOptions` for `buildURL` to be used with `adapterAction` similar to `apiAction` added in d3a5d37665015b8782f2bf84a39c1509f56427d1