### PR TITLE
Drop support for Node.js v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: pnpm
 
       - run: pnpm install
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: pnpm
 
       - run: pnpm install --no-lockfile
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v3.6.0
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: pnpm
 
       - run: pnpm install

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "webpack": "5.84.1"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This should hopefully unblock https://github.com/mainmatter/ember-api-actions/pull/191